### PR TITLE
fix(chart): don't render bars without a computed layout position

### DIFF
--- a/src/components/chart/Bars.jsx
+++ b/src/components/chart/Bars.jsx
@@ -662,7 +662,7 @@ function Bars(props) {
           (isTaskCritical(task) ? ' wx-critical' : '');
         return (
           <Fragment key={task.id}>
-            {!task.$skip && (
+            {!task.$skip && Number.isFinite(task.$x) && (
               <div
                 className={'wx-GKbcLEGA ' + barClass}
                 style={taskStyle(task)}
@@ -749,7 +749,7 @@ function Bars(props) {
                   <Rollups key={i} rollup={rollup} parent={task} />
                 ))
               : null}
-            {baselinesValue && !task.$skip_baseline ? (
+            {baselinesValue && !task.$skip_baseline && Number.isFinite(task.$x_base) ? (
               <div
                 className={
                   'wx-GKbcLEGA wx-baseline' +


### PR DESCRIPTION
Fixes #30

## Problem

A task that never received a computed layout position still renders a `wx-bar` element, producing a confusing "ghost bar":

- When date normalization is skipped — a task with `unscheduled: true`, or any task without a `start` date — the layout math leaves `$x`/`$w` as `NaN`.
- `taskStyle()` then emits `left: "NaNpx"`, `width: "NaNpx"`; the browser rejects the invalid declarations.
- The bar element ends up with only `top`/`height`, so it sits at the chart origin and auto-sizes to its label text. To a user this reads as a real (and very wrong) schedule — the bar's apparent "duration" is the pixel length of its own title.

## Repro

Add a dateless task to any demo dataset, e.g. in `demos/data.js`:

```js
{ id: 999, text: 'Dateless task (ghost bar repro)', parent: 0 },
```

A bar appears at the chart start spanning roughly six "days" — the width of the label.

This is easy to hit from the MIT package: `unscheduledTasks` is disabled in the store's `init()`, but `normalizeDates` still honors the per-task `unscheduled` flag (and `calcDates` is a no-op for tasks with no `start`), so any dateless task paints a ghost bar with no way to opt out.

## Fix

Guard the main bar and the baseline element on `Number.isFinite()` of their computed positions (`$x` / `$x_base`). The row still appears in the grid; nothing is painted on the timeline until the task has real coordinates.

`!= null` is not sufficient — the skipped-normalization path produces `NaN`, not `undefined`.

## Verification

Ran the demos with the repro task above: before — ghost bar at the origin; after — the grid row is present and the timeline row is empty, while all scheduled bars, milestones, summaries and baselines render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)